### PR TITLE
Fix SEQ_LENGTH > config.max_positional_embeddings bug

### DIFF
--- a/megatron_lm/megatron/core/datasets/gpt_dataset.py
+++ b/megatron_lm/megatron/core/datasets/gpt_dataset.py
@@ -99,13 +99,13 @@ class GPTDataset(MegatronDataset):
         """
         text, _ = self._query_document_sample_shuffle_indices(idx)
 
-        text = torch.from_numpy(text)
+        text = torch.from_numpy(text).long()
 
-        tokens = text.long()
-        labels = tokens.clone()
+        tokens = text.contiguous()
+        labels = text.clone().contiguous()
 
         # HF Transformers automatically shift input_ids and labels, so don't shift manually.
-        # ref: Mistral https://github.com/huggingface/transformers/blob/main/src/transformers/models/mistral/modeling_mistral.py#L1171-L1174
+        # ref: Mistral https://github.com/huggingface/transformers/blob/48d35b21789ad80a90ea242e46cb1d53e4db4f1c/src/transformers/models/mistral/modeling_mistral.py#L1211-L1212
         # ref: https://discuss.huggingface.co/t/where-does-the-transformers-do-the-target-text-shifting-in-causal-lm/32408/4
         # Also, if attention mask is all 1(= True), you don't have to pass attention mask.
         # HF Transformers' attention mask is 1 D. so like this. [1, 1, 1, ...., 0, 0]

--- a/megatron_lm/megatron/core/datasets/helpers.cpp
+++ b/megatron_lm/megatron/core/datasets/helpers.cpp
@@ -122,7 +122,7 @@ py::array build_sample_idx(const py::array_t<int32_t> &sizes_,
   while (sample_index <= num_samples)
   {
     // Start with a fresh sequence.
-    int32_t remaining_seq_length = seq_length + 1;
+    int32_t remaining_seq_length = seq_length;
     while (remaining_seq_length != 0)
     {
       // Get the document length.

--- a/scripts/gcp/yi-1.5-9b.sh
+++ b/scripts/gcp/yi-1.5-9b.sh
@@ -2,7 +2,7 @@
 #SBATCH --job-name=yi-1.5-9b
 #SBATCH --partition=a3
 #SBATCH --exclusive
-#SBATCH --nodes 2
+#SBATCH --nodes 1
 #SBATCH --gpus-per-node=8
 #SBATCH --ntasks-per-node=8
 #SBATCH --output=outputs/yi-1.5-9b/%x-%j.out


### PR DESCRIPTION
## About 

Megatron-LM shifts input_ids and labels. But huggingface transformers shift logits and labels in model's forward.
https://github.com/NVIDIA/Megatron-LM/blob/54b4de5b0409313ad11b549f488cb5dc5193ef03/megatron/core/datasets/gpt_dataset.py#L167-L169

Megatron-LM sampling SEQ_LEN+1 length texts from datasets, and then shift (= slice), give it to model.

If you apply the behavior of the Megatron-LM dataset as is, there are cases where input_ids that exceed max_positional_embeddings are passed to the model. 
This can cause confusion in the model and is a problem. 
Therefore, I have made the text length obtained from the dataset the same as SEQ_LEN. 

This problem is caused by the difference in where Megatron-LM and huggingface transformers shift input_ids and labels.

## check

- [x] watch 500 iteration loss behavior
- [ ] inference checkpoint for 500iteration trained model